### PR TITLE
Replace docker-compose with docker compose in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,14 @@ format:
 # Build and run service in docker environment
 .PHONY: docker-start-service-debug docker-start-service-release
 docker-start-service-debug docker-start-service-release: docker-start-service-%:
-	@docker-compose run -p 8080:8080 --rm service_template-container $(MAKE) -- --in-docker-start-$*
+	@docker compose run -p 8080:8080 --rm service_template-container $(MAKE) -- --in-docker-start-$*
 
 # Start specific target in docker environment
 .PHONY: docker-cmake-debug docker-build-debug docker-test-debug docker-clean-debug docker-install-debug docker-cmake-release docker-build-release docker-test-release docker-clean-release docker-install-release
 docker-cmake-debug docker-build-debug docker-test-debug docker-clean-debug docker-install-debug docker-cmake-release docker-build-release docker-test-release docker-clean-release docker-install-release: docker-%:
-	docker-compose run --rm service_template-container $(MAKE) $*
+	docker compose run --rm service_template-container $(MAKE) $*
 
 # Stop docker container and cleanup data
 .PHONY: docker-clean-data
 docker-clean-data:
-	@docker-compose down -v
+	@docker compose down -v


### PR DESCRIPTION
closes #49 

`docker-compose` это бинарник для старой версии утилиты (Compose V1), которая [с июля 2023 года больше не поддерживается и не поставляется с Docker Desktop](https://docs.docker.com/compose/), а [последний релиз которой был и того дальше](https://docs.docker.com/compose/migrate/#can-i-still-use-compose-v1-if-i-want-to).

![image](https://github.com/userver-framework/pg_service_template/assets/47888628/48dc38a0-f9f2-43ca-b706-9563fa7ab7dc)

Новая версия (Compose V2) существует и поставляется уже три года - дольше, чем этот репозиторий, так что переход на него должен быть полностью ок.